### PR TITLE
let a repo specifcy a web font by readign arbitrary custom meta data in index.json

### DIFF
--- a/.dev.vars
+++ b/.dev.vars
@@ -1,6 +1,7 @@
-// todo: replace these with real env driven url of azure api
-// https://developers.cloudflare.com/workers/platform/environment-variables/
-// This below is for local scripture rendering pipeline: 
-// HTML_API_URL_BASE="http://localhost/u"
+# https://developers.cloudflare.com/workers/platform/environment-variables/#add-secrets-to-your-project
+
+# by default, pipeline api_url_base is the dev instance of the pipeline If you are wanting to check this against a local azurite version of blob storage.. you can use (as long as your azurite buckets are public): 
+#PIPELINE_API_URL_BASE = http://127.0.0.1:10000/devstoreaccount1/web/u
+
 PIPELINE_API_URL_BASE="https://read-dev.bibletranslationtools.org/u"
 CHECK_VALID_REPO_URL="http://localhost:8080/api/CheckRepoExists?url=https://content.bibletranslationtools.org"

--- a/src/customTypes/types.ts
+++ b/src/customTypes/types.ts
@@ -89,6 +89,9 @@ export interface repoIndexObj {
       }[]
     | []
   wholeResourceByteCount: number
+  appMeta: {
+    [key: string]: JSONValue
+  }
 }
 
 export interface bibleSchemaPropsType {
@@ -143,3 +146,9 @@ export interface ISavedInServiceWorkerStatus {
   currentBookIsOutOfDate: null | boolean
 }
 export type ILoadingTextEnums = "IDLE" | "FINISHED" | "STARTED" | "ERROR"
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | { [x: string]: JSONValue }
+  | Array<JSONValue>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,8 @@ export interface Props {
   use100vh?: boolean
   textDir: string
   repoUrl: string
+  customFont?: string | null
+  customFontFamily?: string | null
 }
 // imports
 import { pwaInfo } from "virtual:pwa-info"
@@ -12,7 +14,8 @@ import { Nav } from "@components"
 import { getPreferredLangFromHeader } from "@lib/utils"
 
 // data
-const { title, use100vh, textDir, repoUrl } = Astro.props
+const { title, use100vh, textDir, repoUrl, customFont, customFontFamily } =
+  Astro.props
 
 const preferredLocale = getPreferredLangFromHeader(Astro.request)
 let initialDictModule = await import(`../translations/${preferredLocale}.js`)
@@ -41,6 +44,17 @@ const initialDict = {
       href="/fonts/atkinson/atkinson-hyperlegible-v10-latin-ext_latin-700.woff2"
       crossorigin
     />
+    {
+      customFont && customFontFamily && (
+        <link
+          rel="preload"
+          as="font"
+          type="font/woff2"
+          href={customFont}
+          crossorigin
+        />
+      )
+    }
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <meta name="description" content="A site to read rendered USFM" />
@@ -55,7 +69,12 @@ const initialDict = {
     }
     {pwaInfo && <Fragment set:html={pwaInfo.webManifest.linkTag} />}
   </head>
-  <body>
+  <body
+    style={customFont && customFontFamily
+      ? { "font-family": customFontFamily }
+      : null}
+    class={customFont && customFontFamily && "usingCustomFont"}
+  >
     <div class={use100vh ? "print:block print:pb-20" : ""} id="pageWrapper">
       <Nav
         preferredLocale={preferredLocale}

--- a/src/pages/[user]/[repo].astro
+++ b/src/pages/[user]/[repo].astro
@@ -173,6 +173,16 @@ const initialDictModule = await import(
 const initialDict = {
   [preferredLocale]: initialDictModule.default
 }
+
+const customFont =
+  repoIndex.appMeta?.fontUrl && typeof repoIndex.appMeta?.fontUrl == "string"
+    ? repoIndex.appMeta?.fontUrl
+    : null
+const customFontFamily =
+  repoIndex.appMeta?.fontFamily &&
+  typeof repoIndex.appMeta?.fontFamily == "string"
+    ? repoIndex.appMeta?.fontFamily
+    : null
 ---
 
 <Layout
@@ -180,6 +190,8 @@ const initialDict = {
   use100vh={true}
   textDir={repoIndex.textDirection}
   repoUrl={repoIndex.repoUrl}
+  customFont={customFont}
+  customFontFamily={customFontFamily}
 >
   <CommonWrapper resourceType={repoIndex.resourceType} client:load>
     <!-- #=============== BIBLE SCHEMA  ============= -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,10 @@
   --screenHeight: 100vh;
   --marginIncrement: 0.25rem;
 }
+.usingCustomFont .font-sans {
+  font-family: inherit;
+}
+
 /* Fluid font size variables, for browsers that support clamp */
 /* link */ /* https://www.fluid-type-scale.com/calculate?minFontSize=18&minWidth=300&minRatio=1.067&maxFontSize=18&maxWidth=1200&maxRatio=1.2&steps=sm%2Cbase%2Cmd%2Clg%2Cxl%2Cxxl%2Cxxxl&baseStep=base&prefix=font-size&decimals=2&includeFallbacks=on&useRems=on&remValue=16&previewFont=Inter */
 @supports (font-size: clamp(1rem, 1vw, 1rem)) {
@@ -79,31 +83,8 @@
     url("/fonts/atkinson/atkinson-hyperlegible-v10-latin-ext_latin-700.woff")
       format("woff");
 }
+
 /* #===============  FONT FACE   =============   */
-
-/* @=============== scrollbar   ============= */
-
-/* .theText::-webkit-scrollbar,
-.customScrollBar::-webkit-scrollbar {
-  width: 12px;
-}
-.theText,
-.customScrollBar {
-  scrollbar-width: thin;
-  scrollbar-color: var(--thumbBG) var(--scrollbarBG);
-  overflow-wrap: anywhere;
-}
-.theText::-webkit-scrollbar-track,
-.customScrollBar::-webkit-scrollbar-track {
-  background: var(--scrollbarBG);
-}
-.theText::-webkit-scrollbar-thumb,
-.customScrollBar::-webkit-scrollbar-thumb {
-  background-color: var(--thumbBG);
-  border-radius: 6px;
-  border: 3px solid var(--scrollbarBG);
-} */
-/*# =============== scrollbar   ============= */
 
 /* @ =============== addl utils   ============= */
 .sentenceCase {


### PR DESCRIPTION
Reads appMeta from index.json.  
Specicially for loading custom fonts from a wacs repo:
1. Check for existing of said font meta on index.json
![image](https://user-images.githubusercontent.com/67284402/232149597-7aec2f79-ddcf-4194-a428-e7eab7faa745.png)

2. (this is jsx running on a server. Hence the curly brackets) If present, inject link (in this case its google fonts) into the head to prefetch. 
![image](https://user-images.githubusercontent.com/67284402/232149818-9e272234-f582-47f0-bc57-eabaa099e39c.png)

3. Augment the body tag if available. 
![image](https://user-images.githubusercontent.com/67284402/232149909-850fed5b-462c-4807-8817-aae0787b7bb6.png)


Compare ulb:

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/67284402/232150231-d4fe713d-61d3-4b78-92a0-a76b30287eb7.png">
To Urdu repo:
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/67284402/232150571-88751526-a27b-4213-a66d-cf919543fd38.png">

@PurpleGuitar  - Not sure if you want to tag Reuben or anyone else. 